### PR TITLE
fix margins on wider screens to extend color

### DIFF
--- a/src/components/layout/Main.module.scss
+++ b/src/components/layout/Main.module.scss
@@ -1,9 +1,7 @@
 @import '../../styles/vars.scss';
 
 .main {
-  margin: auto;
-  // padding: 1.5rem;
   display: flex;
   flex-direction: column;
-  max-width: $max-content-width;
+  width: 100%;
 }

--- a/src/components/layout/layout.scss
+++ b/src/components/layout/layout.scss
@@ -1,12 +1,13 @@
 @import '../../styles/vars.scss';
 
 .layoutContainer {
-  max-width: $max-content-width;
-  padding: 0 1.25rem;
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
 }
 
 .layoutContent {
-  width: 100%;
+  max-width: $max-content-width;
+  margin: auto;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
Fixes the margins on wider screens to extend the colored sections all the way.

Closes #11 

![fixed-margin](https://user-images.githubusercontent.com/2539760/225133852-7512c857-2461-4644-93f6-92884ca941c2.png)
